### PR TITLE
Switch to sans-serif font family

### DIFF
--- a/lock_screen.c
+++ b/lock_screen.c
@@ -43,7 +43,7 @@ static void draw_stripes(cairo_t * cc,
 
     cairo_set_source_uint32(cc, fg);
     cairo_set_font_size(cc, TEXT_SIZE);
-    cairo_select_font_face(cc, "Sans",
+    cairo_select_font_face(cc, "sans-serif",
             CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
 
     // calculate text and stripe size
@@ -98,7 +98,7 @@ void draw_input_box(cairo_t * cc,
     // U+25CF BLACK CIRCLE, UTF-8 encoding
     static const char dot[] = {0xE2, 0x97, 0x8F, 0x00};
     cairo_set_font_size(cc, TEXT_SIZE * 0.75);
-    cairo_select_font_face(cc, "Sans",
+    cairo_select_font_face(cc, "sans-serif",
             CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
 
     cairo_text_extents_t te;


### PR DESCRIPTION
Hi,

thanks for the PAM-less locker with proper multi-screen detection for Zaphod mode (i3lock failed to accomplish that via xrandr – I used [no-PAM patch](https://gist.github.com/vaygr/1f8454bc4077b59e5b133436214793be) from the [slackbuild](https://slackbuilds.org/repository/14.2/desktop/i3lock/)).

As far as I know, there's no `Sans` family. The correct name seems to be `Sans-Serif`. This is important in case you want to override default family name in `~/.fonts.conf` as per [fontconfig configuration](https://www.freedesktop.org/software/fontconfig/fontconfig-user.html).

This affects users with `ttf-bitstream-vera` package installed, which takes precedence over `dejavu-ttf` which has Unicode symbols like [U+25CF](https://www.fileformat.info/info/unicode/char/25cf/index.htm) that's used here. So with `Sans` in place the following config won't work:

```
<?xml version="1.0"?>
<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
<fontconfig>
	<alias>
		<family>Sans</family>
		<prefer>
			<family>DejaVu Sans</family>
		</prefer>
	</alias>
</fontconfig>
```

This PR fixes it.